### PR TITLE
Implement voice resuming

### DIFF
--- a/core/src/main/java/moe/kyokobot/koe/MediaConnection.java
+++ b/core/src/main/java/moe/kyokobot/koe/MediaConnection.java
@@ -26,7 +26,7 @@ public interface MediaConnection extends Closeable {
      */
     void disconnect();
 
-    CompletableFuture<Void> reconnect();
+    void reconnect();
 
     @NotNull
     KoeClient getClient();

--- a/core/src/main/java/moe/kyokobot/koe/MediaConnection.java
+++ b/core/src/main/java/moe/kyokobot/koe/MediaConnection.java
@@ -8,6 +8,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.io.Closeable;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 
 public interface MediaConnection extends Closeable {
@@ -24,6 +25,8 @@ public interface MediaConnection extends Closeable {
      * @see #connect(VoiceServerInfo)
      */
     void disconnect();
+
+    CompletableFuture<Void> reconnect();
 
     @NotNull
     KoeClient getClient();

--- a/core/src/main/java/moe/kyokobot/koe/gateway/AbstractMediaGatewayConnection.java
+++ b/core/src/main/java/moe/kyokobot/koe/gateway/AbstractMediaGatewayConnection.java
@@ -118,7 +118,6 @@ public abstract class AbstractMediaGatewayConnection implements MediaGatewayConn
     protected void onClose(int code, @Nullable String reason, boolean remote) {
         if (!closed) {
             closed = true;
-            connection.getDispatcher().gatewayClosed(code, reason, remote);
 
             switch (code) {
                 case 1006: // Abnormal closure
@@ -127,6 +126,9 @@ public abstract class AbstractMediaGatewayConnection implements MediaGatewayConn
                 case 4900: // Koe: Reconnect
                     connectFuture = new CompletableFuture<>();
                     start();
+                    break;
+                default:
+                    connection.getDispatcher().gatewayClosed(code, reason, remote);
                     break;
             }
         }

--- a/core/src/main/java/moe/kyokobot/koe/gateway/AbstractMediaGatewayConnection.java
+++ b/core/src/main/java/moe/kyokobot/koe/gateway/AbstractMediaGatewayConnection.java
@@ -49,7 +49,6 @@ public abstract class AbstractMediaGatewayConnection implements MediaGatewayConn
     protected Channel channel;
     protected boolean resumable = false;
     private boolean open = false;
-    private boolean closed = false;
 
     public AbstractMediaGatewayConnection(@NotNull MediaConnectionImpl connection,
                                           @NotNull VoiceServerInfo voiceServerInfo,
@@ -138,10 +137,7 @@ public abstract class AbstractMediaGatewayConnection implements MediaGatewayConn
     protected abstract void handlePayload(JsonObject object);
 
     protected void onClose(int code, @Nullable String reason, boolean remote) {
-        if (!closed) {
-            closed = true;
-            connection.getDispatcher().gatewayClosed(code, reason, remote);
-        }
+        connection.getDispatcher().gatewayClosed(code, reason, remote);
     }
 
     @Override

--- a/core/src/main/java/moe/kyokobot/koe/gateway/AbstractMediaGatewayConnection.java
+++ b/core/src/main/java/moe/kyokobot/koe/gateway/AbstractMediaGatewayConnection.java
@@ -125,6 +125,7 @@ public abstract class AbstractMediaGatewayConnection implements MediaGatewayConn
                 case 4000: // Internal error
                 case 4015: // Voice server crashed
                 case 4900: // Koe: Reconnect
+                    connectFuture = new CompletableFuture<>();
                     start();
                     break;
             }

--- a/core/src/main/java/moe/kyokobot/koe/gateway/AbstractMediaGatewayConnection.java
+++ b/core/src/main/java/moe/kyokobot/koe/gateway/AbstractMediaGatewayConnection.java
@@ -89,16 +89,16 @@ public abstract class AbstractMediaGatewayConnection implements MediaGatewayConn
                 channel.writeAndFlush(new CloseWebSocketFrame(code, reason));
             }
             channel.close();
+
+            onClose(code, reason, false);
+
+            if (reconnect) {
+                reconnect();
+            }
         }
 
         if (!connectFuture.isDone()) {
             connectFuture.completeExceptionally(new NotYetConnectedException());
-        }
-
-        onClose(code, reason, false);
-
-        if (reconnect) {
-            reconnect();
         }
     }
 

--- a/core/src/main/java/moe/kyokobot/koe/gateway/AbstractMediaGatewayConnection.java
+++ b/core/src/main/java/moe/kyokobot/koe/gateway/AbstractMediaGatewayConnection.java
@@ -114,8 +114,12 @@ public abstract class AbstractMediaGatewayConnection implements MediaGatewayConn
             var future = new CompletableFuture<Void>();
             channel.closeFuture().addListener(new NettyFutureWrapper<>(future));
 
-            future.thenAccept(v -> start());
+            future.thenAccept(v -> {
+                connectFuture = new CompletableFuture<>();
+                start();
+            });
         } else {
+            connectFuture = new CompletableFuture<>();
             start();
         }
 

--- a/core/src/main/java/moe/kyokobot/koe/gateway/MediaGatewayConnection.java
+++ b/core/src/main/java/moe/kyokobot/koe/gateway/MediaGatewayConnection.java
@@ -11,9 +11,9 @@ public interface MediaGatewayConnection {
 
     CompletableFuture<Void> start();
 
-    void close(int code, @Nullable String reason, boolean reconnect);
+    void close(int code, @Nullable String reason);
 
-    CompletableFuture<Void> reconnect();
+    void reconnect();
 
     void updateSpeaking(int mask);
 }

--- a/core/src/main/java/moe/kyokobot/koe/gateway/MediaGatewayConnection.java
+++ b/core/src/main/java/moe/kyokobot/koe/gateway/MediaGatewayConnection.java
@@ -11,7 +11,9 @@ public interface MediaGatewayConnection {
 
     CompletableFuture<Void> start();
 
-    void close(int code, @Nullable String reason);
+    void close(int code, @Nullable String reason, boolean reconnect);
+
+    CompletableFuture<Void> reconnect();
 
     void updateSpeaking(int mask);
 }

--- a/core/src/main/java/moe/kyokobot/koe/gateway/MediaGatewayV4Connection.java
+++ b/core/src/main/java/moe/kyokobot/koe/gateway/MediaGatewayV4Connection.java
@@ -52,6 +52,15 @@ public class MediaGatewayV4Connection extends AbstractMediaGatewayConnection {
     }
 
     @Override
+    protected void resume() {
+        logger.debug("Resuming...");
+        sendInternalPayload(Op.RESUME, new JsonObject()
+                .addAsString("server_id", connection.getGuildId())
+                .add("session_id", voiceServerInfo.getSessionId())
+                .add("token", voiceServerInfo.getToken()));
+    }
+
+    @Override
     protected void handlePayload(JsonObject object) {
         var op = object.getInt("op");
 
@@ -65,6 +74,8 @@ public class MediaGatewayV4Connection extends AbstractMediaGatewayConnection {
                 break;
             }
             case Op.READY: {
+                resumable = true;
+
                 var data = object.getObject("d");
                 var port = data.getInt("port");
                 var ip = data.getString("ip");
@@ -96,6 +107,10 @@ public class MediaGatewayV4Connection extends AbstractMediaGatewayConnection {
             }
             case Op.HEARTBEAT_ACK: {
                 this.ping = System.currentTimeMillis() - this.lastHeartbeatSent;
+                break;
+            }
+            case Op.RESUMED: {
+                logger.debug("Resumed successfully");
                 break;
             }
             case Op.CLIENT_CONNECT: {

--- a/core/src/main/java/moe/kyokobot/koe/gateway/MediaGatewayV5Connection.java
+++ b/core/src/main/java/moe/kyokobot/koe/gateway/MediaGatewayV5Connection.java
@@ -49,6 +49,16 @@ public class MediaGatewayV5Connection extends AbstractMediaGatewayConnection {
     }
 
     @Override
+    protected void resume() {
+        logger.debug("Resuming...");
+        sendInternalPayload(Op.RESUME, new JsonObject()
+                .addAsString("server_id", connection.getGuildId())
+                .add("session_id", voiceServerInfo.getSessionId())
+                .add("token", voiceServerInfo.getToken())
+                .add("video", true));
+    }
+
+    @Override
     protected void handlePayload(JsonObject object) {
         var op = object.getInt("op");
 
@@ -62,6 +72,8 @@ public class MediaGatewayV5Connection extends AbstractMediaGatewayConnection {
                 break;
             }
             case Op.READY: {
+                resumable = true;
+
                 var data = object.getObject("d");
                 var port = data.getInt("port");
                 var ip = data.getString("ip");
@@ -93,6 +105,10 @@ public class MediaGatewayV5Connection extends AbstractMediaGatewayConnection {
             }
             case Op.HEARTBEAT_ACK: {
                 this.ping = System.currentTimeMillis() - this.lastHeartbeatSent;
+                break;
+            }
+            case Op.RESUMED: {
+                logger.debug("Resumed successfully");
                 break;
             }
             case Op.CLIENT_CONNECT: {

--- a/core/src/main/java/moe/kyokobot/koe/internal/MediaConnectionImpl.java
+++ b/core/src/main/java/moe/kyokobot/koe/internal/MediaConnectionImpl.java
@@ -14,7 +14,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Objects;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 
 public class MediaConnectionImpl implements MediaConnection {
@@ -62,7 +61,7 @@ public class MediaConnectionImpl implements MediaConnection {
         stopVideoFramePolling();
 
         if (gatewayConnection != null && gatewayConnection.isOpen()) {
-            gatewayConnection.close(1000, null, false);
+            gatewayConnection.close(1000, null);
             gatewayConnection = null;
         }
 
@@ -73,12 +72,12 @@ public class MediaConnectionImpl implements MediaConnection {
     }
 
     @Override
-    public CompletableFuture<Void> reconnect() {
+    public void reconnect() {
         logger.debug("Reconnecting...");
 
-        if (gatewayConnection == null) return null;
-
-        return gatewayConnection.reconnect();
+        if (gatewayConnection != null) {
+            gatewayConnection.reconnect();
+        }
     }
 
     @Override

--- a/core/src/main/java/moe/kyokobot/koe/internal/MediaConnectionImpl.java
+++ b/core/src/main/java/moe/kyokobot/koe/internal/MediaConnectionImpl.java
@@ -14,6 +14,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 
 public class MediaConnectionImpl implements MediaConnection {
@@ -61,7 +62,7 @@ public class MediaConnectionImpl implements MediaConnection {
         stopVideoFramePolling();
 
         if (gatewayConnection != null && gatewayConnection.isOpen()) {
-            gatewayConnection.close(1000, null);
+            gatewayConnection.close(1000, null, false);
             gatewayConnection = null;
         }
 
@@ -69,6 +70,15 @@ public class MediaConnectionImpl implements MediaConnection {
             connectionHandler.close();
             connectionHandler = null;
         }
+    }
+
+    @Override
+    public CompletableFuture<Void> reconnect() {
+        logger.debug("Reconnecting...");
+
+        if (gatewayConnection == null) return null;
+
+        return gatewayConnection.reconnect();
     }
 
     @Override


### PR DESCRIPTION
- Added `MediaConnection.reconnect()` function, to force voice gateway reconnection
- The voice gateway connection will be resumed on close codes:
- - 1006 (Abnormal closure)
- - 4000 (Websocket error)
- - 4015 ([Voice server crashed](https://discord.com/developers/docs/topics/opcodes-and-status-codes#voice-voice-close-event-codes))
- - 4900 (Koe: reconnect) - close code when you use `MediaConnection.reconnect()`
- **The gatewayClosed event won't be called on the close codes above.**

- [x] Tested

Some **testing logs** (tested on us-east and rotterdam voice servers)
> **NOTES:**
> - "Manual WS close" log in AbstractMediaGatewayConnection.close()
> - "Manual WS close. Closing channel... " log if AbstractMediaGatewayConnection.close() is called with channel opened
> - The close codes 1006 were only called by netty channelInactive method
> - The netty channelInactive method is always called on gateway disconnects, even on clean close codes
> - The bot keeps playing music after resuming ✔

```console
2022-02-14 10:38:42.342  INFO 26 --- [tLoopGroup-3-11] m.k.k.g.AbstractMediaGatewayConnection   : Manual WS close. Code: 1006. Reason: Abnormal closure 
2022-02-14 10:38:42.342  INFO 26 --- [tLoopGroup-3-11] m.k.k.g.AbstractMediaGatewayConnection   : Connecting to wss://us-east3136.discord.media:443/?v=4 
2022-02-14 10:38:42.862  INFO 26 --- [ntLoopGroup-3-4] m.k.k.gateway.MediaGatewayV4Connection   : Resuming... 
2022-02-14 10:38:42.864  INFO 26 --- [ntLoopGroup-3-4] m.k.k.gateway.MediaGatewayV4Connection   : Received HELLO, heartbeat interval: 13750 
2022-02-14 10:38:42.864  INFO 26 --- [ntLoopGroup-3-4] m.k.k.gateway.MediaGatewayV4Connection   : Setting up heartbeats... 
2022-02-14 10:38:42.952  INFO 26 --- [ntLoopGroup-3-4] m.k.k.gateway.MediaGatewayV4Connection   : Resumed successfully 

2022-02-14 11:14:19.678  INFO 26 --- [ntLoopGroup-3-7] m.k.k.g.AbstractMediaGatewayConnection   : Manual WS close. Code: 1006. Reason: Abnormal closure 
2022-02-14 11:14:19.679  INFO 26 --- [ntLoopGroup-3-7] m.k.k.g.AbstractMediaGatewayConnection   : Connecting to wss://rotterdam9626.discord.media:443/?v=4 
2022-02-14 11:14:19.797  INFO 26 --- [ntLoopGroup-3-3] m.k.k.gateway.MediaGatewayV4Connection   : Resuming... 
2022-02-14 11:14:19.798  INFO 26 --- [ntLoopGroup-3-3] m.k.k.gateway.MediaGatewayV4Connection   : Received HELLO, heartbeat interval: 13750 
2022-02-14 11:14:19.798  INFO 26 --- [ntLoopGroup-3-3] m.k.k.gateway.MediaGatewayV4Connection   : Setting up heartbeats... 
2022-02-14 11:14:19.829  INFO 26 --- [ntLoopGroup-3-3] m.k.k.gateway.MediaGatewayV4Connection   : Resumed successfully 

2022-02-14 11:25:36.458  INFO 26 --- [ntLoopGroup-3-4] m.k.k.g.AbstractMediaGatewayConnection   : Manual WS close. Code: 1006. Reason: Abnormal closure 
2022-02-14 11:25:36.458  INFO 26 --- [ntLoopGroup-3-4] m.k.k.g.AbstractMediaGatewayConnection   : Connecting to wss://us-east3136.discord.media:443/?v=4 
2022-02-14 11:25:36.835  INFO 26 --- [ntLoopGroup-3-2] m.k.k.gateway.MediaGatewayV4Connection   : Resuming... 
2022-02-14 11:25:36.835  INFO 26 --- [ntLoopGroup-3-2] m.k.k.gateway.MediaGatewayV4Connection   : Received HELLO, heartbeat interval: 13750 
2022-02-14 11:25:36.836  INFO 26 --- [ntLoopGroup-3-2] m.k.k.gateway.MediaGatewayV4Connection   : Setting up heartbeats... 
2022-02-14 11:25:36.948  INFO 26 --- [ntLoopGroup-3-2] m.k.k.gateway.MediaGatewayV4Connection   : Resumed successfully 

2022-02-14 11:59:14.810  INFO 26 --- [ntLoopGroup-3-3] m.k.k.g.AbstractMediaGatewayConnection   : Manual WS close. Code: 4000. Reason: Internal error 
2022-02-14 11:59:14.810  INFO 26 --- [ntLoopGroup-3-3] m.k.k.g.AbstractMediaGatewayConnection   : Manual WS close. Closing channel... 
2022-02-14 11:59:14.810  INFO 26 --- [ntLoopGroup-3-3] m.k.k.g.AbstractMediaGatewayConnection   : Connecting to wss://rotterdam9626.discord.media:443/?v=4 
2022-02-14 11:59:14.811 ERROR 26 --- [ntLoopGroup-3-3] m.k.k.g.AbstractMediaGatewayConnection   : Websocket error 
io.netty.channel.unix.Errors$NativeIoException: readAddress(..) failed: Connection reset by peer 
2022-02-14 11:59:14.811  INFO 26 --- [ntLoopGroup-3-3] m.k.k.g.AbstractMediaGatewayConnection   : Manual WS close. Code: 1006. Reason: Abnormal closure 
2022-02-14 11:59:14.927  INFO 26 --- [ntLoopGroup-3-4] m.k.k.gateway.MediaGatewayV4Connection   : Resuming... 
2022-02-14 11:59:14.927  INFO 26 --- [ntLoopGroup-3-4] m.k.k.gateway.MediaGatewayV4Connection   : Received HELLO, heartbeat interval: 13750 
2022-02-14 11:59:14.928  INFO 26 --- [ntLoopGroup-3-4] m.k.k.gateway.MediaGatewayV4Connection   : Setting up heartbeats... 
2022-02-14 11:59:14.948  INFO 26 --- [ntLoopGroup-3-4] m.k.k.gateway.MediaGatewayV4Connection   : Resumed successfully 
```